### PR TITLE
Move shared types to their own package.

### DIFF
--- a/packages/ingester/package.json
+++ b/packages/ingester/package.json
@@ -20,6 +20,7 @@
     "@vercel/node": "^2.15.5",
     "commander": "^11.0.0",
     "eslint": "^8.44.0",
+    "podverse-types": "*",
     "rss-parser": "^3.13.0",
     "slug": "^8.2.2",
     "terminal-kit": "^3.0.0"

--- a/packages/ingester/src/main.ts
+++ b/packages/ingester/src/main.ts
@@ -4,20 +4,14 @@ import Parser from 'rss-parser';
 import terminal from 'terminal-kit';
 const { terminal: term } = terminal;
 import slug from 'slug';
+import { Podcast } from 'podverse-types';
 
 program.name('ingester').version('0.0.1').description('Ingest a podcast into the Podverse app.');
-
-type Podcast = {
-  slug: string;
-  title: string;
-  description?: string;
-  imageUrl?: string;
-  corpusId?: string;
-};
 
 program
   .command('ingest <podcastUrl>')
   .option('-f, --force', 'Force ingestion even if podcast already exists.')
+  .option('--corpus [corpusId]', 'Fixie Corpus ID to use for this podcast.')
   .action(async (podcastUrl: string) => {
     // Read the RSS feed metadata.
     const parser = new Parser();
@@ -43,6 +37,7 @@ program
       title: feed.title,
       description: feed.description,
       imageUrl: feed.image?.url,
+      corpusId: program.opts().corpus,
     };
 
     // Write the podcast to KV.

--- a/packages/podverse-types/.eslintrc.cjs
+++ b/packages/podverse-types/.eslintrc.cjs
@@ -1,0 +1,28 @@
+module.exports = {
+  env: {
+    node: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  overrides: [
+    {
+      env: {
+        node: true,
+      },
+      files: ['.eslintrc.{js,cjs}'],
+      parserOptions: {
+        sourceType: 'script',
+      },
+    },
+  ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  rules: {
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/podverse-types/package.json
+++ b/packages/podverse-types/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "podverse-types",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/types.ts",
+  "types": "src/types.ts",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "format": "prettier --write .",
+    "lint": "eslint ."
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.44.0",
+    "prettier": "^3.0.0",
+    "typescript": "5.1.3"
+  }
+}

--- a/packages/podverse-types/src/types.ts
+++ b/packages/podverse-types/src/types.ts
@@ -1,0 +1,22 @@
+/**
+ * This file contains type definitions shared between the different packages.
+ */
+
+/** Represents metadata for a podcast. */
+export type Podcast = {
+  slug: string;
+  title: string;
+  description?: string;
+  imageUrl?: string;
+  corpusId?: string;
+  episodes?: Episode[];
+};
+
+/** Represents metadata for a single episode. */
+export type Episode = {
+  title: string;
+  description?: string;
+  pubDate?: string;
+  audioUrl?: string;
+  transcriptUrl?: string;
+};

--- a/packages/podverse-types/tsconfig.json
+++ b/packages/podverse-types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020", // Node.js 14
+    "strict": true,
+    "noEmitOnError": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "module": "node16",
+    "moduleResolution": "nodenext",
+    "jsx": "react",
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src"]
+}

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -17,6 +17,7 @@
     "eslint": "8.43.0",
     "eslint-config-next": "13.4.7",
     "next": "13.4.7",
+    "podverse-types": "*",
     "postcss": "8.4.24",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/webapp/src/app/api/podcasts/route.ts
+++ b/packages/webapp/src/app/api/podcasts/route.ts
@@ -5,6 +5,7 @@
 export const runtime = 'edge';
 
 import { kv } from '@vercel/kv';
+import { Podcast } from 'podverse-types';
 
 /** Return a list of all podcasts. */
 export async function GET(req: Request): Promise<Response> {
@@ -14,7 +15,7 @@ export async function GET(req: Request): Promise<Response> {
   const podcastData = await Promise.all(
     keys.map(async (key) => {
       const podcast = await kv.json.get(key, '$');
-      return podcast[0];
+      return podcast[0] as Podcast;
     })
   );
   return new Response(JSON.stringify(podcastData), {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2946,6 +2946,7 @@ __metadata:
     "@vercel/node": ^2.15.5
     commander: ^11.0.0
     eslint: ^8.44.0
+    podverse-types: "*"
     prettier: ^3.0.0
     rss-parser: ^3.13.0
     slug: ^8.2.2
@@ -4217,6 +4218,18 @@ __metadata:
     prettier: ^2.8.8
     turbo: ^1.10.7
     typescript: ^5.1.3
+  languageName: unknown
+  linkType: soft
+
+"podverse-types@*, podverse-types@workspace:packages/podverse-types":
+  version: 0.0.0-use.local
+  resolution: "podverse-types@workspace:packages/podverse-types"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": ^6.0.0
+    "@typescript-eslint/parser": ^6.0.0
+    eslint: ^8.44.0
+    prettier: ^3.0.0
+    typescript: 5.1.3
   languageName: unknown
   linkType: soft
 
@@ -5544,6 +5557,7 @@ __metadata:
     eslint: 8.43.0
     eslint-config-next: 13.4.7
     next: 13.4.7
+    podverse-types: "*"
     postcss: 8.4.24
     react: 18.2.0
     react-dom: 18.2.0


### PR DESCRIPTION
This PR migrates the `Podcast` type to its own shared package, `podverse-types`, which can be imported by both the webapp and ingester packages. This way we can share those types across the two packages without having to duplicate.